### PR TITLE
fix: shutdown works even on error.

### DIFF
--- a/fed/_private/message_queue.py
+++ b/fed/_private/message_queue.py
@@ -57,7 +57,9 @@ class MessageQueueManager:
                 f"Starting new thread[{self._thread_name}] for message polling."
             )
             self._queue = deque()
-            self._thread = threading.Thread(target=_loop, name=self._thread_name)
+            self._thread = threading.Thread(
+                target=_loop, name=self._thread_name, daemon=True
+            )
             self._thread.start()
 
     def append(self, message):

--- a/fed/tests/test_brpc_link.py
+++ b/fed/tests/test_brpc_link.py
@@ -98,7 +98,7 @@ def shutdown_on_error(party):
     def sleep_fun(a):
         import time
 
-        time.sleep(20)
+        time.sleep(86400)
 
         return a
 
@@ -121,7 +121,7 @@ def shutdown_on_error(party):
     )
 
     try:
-        # Bob will sleep a while
+        # Bob will sleep a long time.
         a = sleep_fun.party('bob').remote(1)
 
         # Alice will get data from bob and brpc link is blocking.

--- a/fed/tests/test_brpc_link.py
+++ b/fed/tests/test_brpc_link.py
@@ -93,6 +93,65 @@ def test_fed_get_in_2_parties():
     assert p_alice.exitcode == 0 and p_bob.exitcode == 0
 
 
+def shutdown_with_error(party):
+    @fed.remote
+    def sleep_fun(a):
+        import time
+
+        time.sleep(20)
+
+        return a
+
+    @fed.remote
+    def ok_fun(a):
+        return a
+
+    compatible_utils.init_ray(address='local')
+    addresses = {
+        'alice': '127.0.0.1:11012',
+        'bob': '127.0.0.1:11011',
+    }
+    from fed.proxy.brpc_link.link import BrpcLinkSenderReceiverProxy
+
+    fed.init(
+        addresses=addresses,
+        party=party,
+        receiver_sender_proxy_cls=BrpcLinkSenderReceiverProxy,
+        logging_level='debug',
+    )
+
+    try:
+        # Bob will sleep a while
+        a = sleep_fun.party('bob').remote(1)
+
+        # Alice will get data from bob and brpc link is blocking.
+        b = ok_fun.party('alice').remote(a)
+
+        c = ok_fun.party('alice').remote(1)
+        # Alice will send c to bob and sending will be blocked by getting.
+        ok_fun.party('bob').remote(c)
+
+        # alice will run into error and exit.
+        if party == 'alice':
+            raise Exception('test')
+    except Exception as e:
+        pass
+    finally:
+        # Alice can shutdown normmaly with a hint with_error==True.
+        fed.shutdown(with_error=True)
+        ray.shutdown()
+
+
+def test_shutdown_with_error_should_ok():
+    p_alice = multiprocessing.Process(target=shutdown_with_error, args=('alice',))
+    p_bob = multiprocessing.Process(target=shutdown_with_error, args=('bob',))
+    p_alice.start()
+    p_bob.start()
+    p_alice.join()
+    p_bob.join()
+    assert p_alice.exitcode == 0
+
+
 if __name__ == "__main__":
     import sys
 

--- a/fed/tests/test_brpc_link.py
+++ b/fed/tests/test_brpc_link.py
@@ -93,7 +93,7 @@ def test_fed_get_in_2_parties():
     assert p_alice.exitcode == 0 and p_bob.exitcode == 0
 
 
-def shutdown_with_error(party):
+def shutdown_on_error(party):
     @fed.remote
     def sleep_fun(a):
         import time
@@ -137,14 +137,14 @@ def shutdown_with_error(party):
     except Exception as e:
         pass
     finally:
-        # Alice can shutdown normmaly with a hint with_error==True.
-        fed.shutdown(with_error=True)
+        # Alice can shutdown normmaly with a hint on_error==True.
+        fed.shutdown(on_error=True)
         ray.shutdown()
 
 
 def test_shutdown_with_error_should_ok():
-    p_alice = multiprocessing.Process(target=shutdown_with_error, args=('alice',))
-    p_bob = multiprocessing.Process(target=shutdown_with_error, args=('bob',))
+    p_alice = multiprocessing.Process(target=shutdown_on_error, args=('alice',))
+    p_bob = multiprocessing.Process(target=shutdown_on_error, args=('bob',))
     p_alice.start()
     p_bob.start()
     p_alice.join()

--- a/setup_secretflow.py
+++ b/setup_secretflow.py
@@ -38,7 +38,7 @@ class CleanCommand(setuptools.Command):
 
 setup(
     name='secretflow-rayfed',
-    version='0.2.1a1',
+    version='0.2.1a2',
     license='Apache 2.0',
     description='A multiple parties joint, distributed execution engine based on Ray,'
                 'to help build your own federated learning frameworks in minutes.',


### PR DESCRIPTION
Shutdown can be blocked in some situation, e.g.
```python
try:
  # Bob will sleep a long time.
  a = sleep_fun.party('bob').remote(1)
  
  # Alice will get data from bob and brpc link is blocking.
  b = ok_fun.party('alice').remote(a)
  
  c = ok_fun.party('alice').remote(1)
  # Alice will send c to bob and sending will be blocked by getting.
  ok_fun.party('bob').remote(c)
  
  # alice will run into error and exit.
  if party == 'alice':
      raise Exception('test')
finally:
  # shutdown will be blocked as data sending is blocked.
  fed.shutdown()
```

We can do less here but give shutdown a hint that some errors occurred and no need to wait for data sending.

